### PR TITLE
perf: fix O(n*m) dedup in querySelectorAll

### DIFF
--- a/lib/domQuery/index.ts
+++ b/lib/domQuery/index.ts
@@ -30,7 +30,21 @@ export function domQuery (contextNode: Element | Document, selector: string): El
   }
 
   // return collection of unique nodes in document order
+
+  if (selectorBits.length === 1) {
+    // Single selector group: results are in document order, just need to
+    // deduplicate (because dupes can happen with descendant combinators)
+    const seen = new Set<Element>();
+    return elements.filter(elm => {
+      if (seen.has(elm)) return false;
+      seen.add(elm);
+      return true;
+    });
+  }
+
+  // Multiple selector groups: restore document order via tree walk
+  const elementSet = new Set(elements);
   return contextNode
     .getElementsByTagName('*')
-    .filter(elm => elements.includes(elm));
+    .filter(elm => elementSet.has(elm));
 }

--- a/test/domQuery-dedup.spec.ts
+++ b/test/domQuery-dedup.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { parseXML } from '../lib/index.js';
+
+describe('domQuery dedup fix', () => {
+  it('preserves document order for single-group selectors', () => {
+    const doc = parseXML('<root><x/><y/><z/></root>');
+    const result = doc.root!.querySelectorAll('*');
+    expect(result.map(e => e.tagName)).toEqual(['x', 'y', 'z']);
+  });
+
+  it('preserves document order for multi-group (comma) selectors', () => {
+    const doc = parseXML('<root><a/><b/><c/></root>');
+    // Even if groups are listed out of document order, results should
+    // be in document order (via the getElementsByTagName tree walk).
+    const result = doc.root!.querySelectorAll('c, a');
+    expect(result.map(e => e.tagName)).toEqual(['a', 'c']);
+  });
+
+  it('deduplicates descendant combinator results', () => {
+    // A descendant selector can match the same element via multiple ancestors.
+    const doc = parseXML('<root><a><a><c/></a></a></root>');
+    // "a c" matches <c> through both <a>'s; should find exactly one <c>
+    const result = doc.root!.querySelectorAll('a c');
+    expect(result.map(e => e.tagName)).toEqual(['c']);
+  });
+
+  it('deduplicates multi-group (comma) selector results', () => {
+    // Two selector groups that both match the same element:
+    // "a c" matches <c> as a descendant of <a>,
+    // "b c" matches <c> as a descendant of <b>.
+    const doc = parseXML('<root><a><b><c/></b></a></root>');
+    const result = doc.root!.querySelectorAll('a c, b c');
+    expect(result.length).toBe(1);
+    expect(result[0].tagName).toBe('c');
+  });
+});


### PR DESCRIPTION
What
---

Fix O(n*m) performance in `domQuery`

How
---

The deduplication step after selector matching did this:

```ts
  contextNode.getElementsByTagName('*')
    .filter(elm => elements.includes(elm))
```

This traverses the entire tree and does a linear `.includes()` scan per element. That makes it O(n*m) where n is the tree size and m is the number of matched elements. For large documents with many matches (e.g. `querySelectorAll` on a sheet with thousands of cells), this can get quite bad.

For single-group selectors (no commas), the filter chain already produces results in document order, so skip the tree walk entirely and just deduplicate seen elements in-place with a Set.

For multi-group selectors (i.e. with commas), keep the tree walk for document order but collect matched elements into a `Set` up front and use `Set.has()` for O(1) lookups.